### PR TITLE
Add Czech translation & fix some English typos

### DIFF
--- a/_locales/cs/pxt-nezha-jsdoc-strings.json
+++ b/_locales/cs/pxt-nezha-jsdoc-strings.json
@@ -1,0 +1,18 @@
+{
+  "neZha": "Multifunkční rozšiřující karta NeZha od ELECFREAKS Co.,Ltd.",
+  "neZha.MotorList": "Seznam motorů",
+  "neZha.ServoList": "Seznam servomotorů",
+  "neZha.setMotorSpeed": "Nastaví rychlost daného motoru.",
+  "neZha.setMotorSpeed|param|motor": "identifikátor motoru, např.: MotorList.M1",
+  "neZha.setMotorSpeed|param|speed": "rychlost motoru v intervalu od -100 do 100, např.: 100",
+  "neZha.setServoAngel": "Nastaví úhel natočení daného serva.",
+  "neZha.setServoAngel|param|servoType": "typ serva, např.: neZha.ServoTypeList._180",
+  "neZha.setServoAngel|param|servo": "identifikátor serva, např.: neZha.ServoList.S1",
+  "neZha.setServoAngel|param|angle": "úhel serva, např.: 90",
+  "neZha.setServoSpeed": "Nastaví rychlost daného kontinuálního serva.",
+  "neZha.setServoSpeed|param|servo": "identifikátor serva, např.: neZha.ServoList.S1",
+  "neZha.setServoSpeed|param|speed": "rychlost serva v intervalu od -100 do 100, např.: 100",
+  "neZha.stopAllMotor": "Zastaví všechny motory (M1, M2, M3 a M4).",
+  "neZha.stopMotor": "Zastaví daný motor.",
+  "neZha.stopMotor|param|motor": "identifikátor motoru, např.: MotorList.M1"
+}

--- a/_locales/cs/pxt-nezha-strings.json
+++ b/_locales/cs/pxt-nezha-strings.json
@@ -1,0 +1,20 @@
+{
+  "neZha.MotorList.M1|block": "M1",
+  "neZha.MotorList.M2|block": "M2",
+  "neZha.MotorList.M3|block": "M3",
+  "neZha.MotorList.M4|block": "M4",
+  "neZha.ServoList.S1|block": "S1",
+  "neZha.ServoList.S2|block": "S2",
+  "neZha.ServoList.S3|block": "S3",
+  "neZha.ServoList.S4|block": "S4",
+  "neZha.ServoTypeList._180|block": "180°",
+  "neZha.ServoTypeList._270|block": "270°",
+  "neZha.ServoTypeList._360|block": "360°",
+  "neZha.setMotorSpeed|block": "nastav rychlost motoru %motor na %speed(rychlost)\\%",
+  "neZha.setServoAngel|block": "nastav úhel %servoType(typ) serva %servo na %angle(úhel)°",
+  "neZha.setServoSpeed|block": "nastav rychlost kontinuálního serva %servo na %speed(rychlost)\\%",
+  "neZha.stopAllMotor|block": "zastav všechny motory",
+  "neZha.stopMotor|block": "zastav motor %motor",
+  "neZha|block": "NeZha",
+  "{id:category}NeZha": "NeZha"
+}

--- a/_locales/pxt-nezha-jsdoc-strings.json
+++ b/_locales/pxt-nezha-jsdoc-strings.json
@@ -1,8 +1,18 @@
 {
-  "neZha": "Functions to NeZha multifunctional expansion board by ELECFREAKS Co.,Ltd.",
+  "neZha": "Functions for NeZha multifunctional expansion board by ELECFREAKS Co.,Ltd.",
   "neZha.MotorList": "MotorList",
   "neZha.ServoList": "ServoList",
-  "neZha.setMotorSpeed": "TODO: Set the speed of M1, M2, M3, M4 motor.",
-  "neZha.setMotorSpeed|param|motor": "M1, M2, M3, M4 motor , eg: MotorList.M1",
-  "neZha.setMotorSpeed|param|speed": "motor speed, eg: 100"
+  "neZha.setMotorSpeed": "Sets the speed of one of the M1, M2, M3 or M4 motors.",
+  "neZha.setMotorSpeed|param|motor": "A motor in the MotorList, eg: MotorList.M1",
+  "neZha.setMotorSpeed|param|speed": "Motor speed ranging from -100 to 100, eg: 100",
+  "neZha.setServoAngel": "Sets the angle of a servo motor.",
+  "neZha.setServoAngel|param|servoType": "A servo type in ServoTypeList, eg: neZha.ServoTypeList._180",
+  "neZha.setServoAngel|param|servo": "A servo in the ServoList, eg: neZha.ServoList.S1",
+  "neZha.setServoAngel|param|angle": "Angle of servo motor, eg: 90",
+  "neZha.setServoSpeed": "Sets the speed of a servo motor.",
+  "neZha.setServoSpeed|param|servo": "A servo in the ServoList, eg: neZha.ServoList.S1",
+  "neZha.setServoSpeed|param|speed": "Speed of the servo motor ranging from -100 to 100, eg: 100",
+  "neZha.stopAllMotor": "Stops all motors, including M1, M2, M3 and M4.",
+  "neZha.stopMotor": "Stops one of the motors.",
+  "neZha.stopMotor|param|motor": "A motor in the MotorList, eg: MotorList.M1"
 }

--- a/_locales/pxt-nezha-strings.json
+++ b/_locales/pxt-nezha-strings.json
@@ -11,9 +11,9 @@
   "neZha.ServoTypeList._270|block": "270°",
   "neZha.ServoTypeList._360|block": "360°",
   "neZha.setMotorSpeed|block": "Set motor %motor speed to %speed\\%",
-  "neZha.setServoAngel|block": "Set %servoType servo %servo angel to %angle°",
+  "neZha.setServoAngel|block": "Set %servoType servo %servo angle to %angle°",
   "neZha.setServoSpeed|block": "Set continuous rotation servo %servo speed to %speed\\%",
-  "neZha.stopAllMotor|block": "Stop all motor",
+  "neZha.stopAllMotor|block": "Stop all motors",
   "neZha.stopMotor|block": "Stop motor %motor",
   "neZha|block": "NeZha",
   "{id:category}NeZha": "NeZha"

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 /**
-* Functions to NeZha multifunctional expansion board by ELECFREAKS Co.,Ltd.
+* Functions for NeZha multifunctional expansion board by ELECFREAKS Co.,Ltd.
 */
 //% color=#ff0000  icon="\uf06d" block="NeZha" blockId="NeZha"
 namespace neZha {
@@ -38,9 +38,10 @@ namespace neZha {
         //% block="360°" 
         _360
     }
+
 	/**
-     * TODO: Set the speed of M1, M2, M3, M4 motor. 
-     * @param motor M1, M2, M3, M4 motor 
+     * Sets the speed of one of the M1, M2, M3 or M4 motors.
+     * @param motor A motor in the MotorList 
      * @param speed motor speed
      */
     //% weight=88
@@ -112,8 +113,8 @@ namespace neZha {
         }
     }
 
-	/*
-     * TODO: Stop one of the motors. 
+	/**
+     * Stops one of the motors.
      * @param motor A motor in the MotorList
      */
     //% weight=86
@@ -121,11 +122,12 @@ namespace neZha {
     export function stopMotor(motor: MotorList): void {
         setMotorSpeed(motor, 0)
     }
-	/*
-     * TODO: Stop all motors, including M1, M2, M3, M4.
+
+	/**
+     * Stops all motors, including M1, M2, M3 and M4.
      */
     //% weight=85
-    //% blockId=stopAllMotor  block="Stop all motor"
+    //% blockId=stopAllMotor  block="Stop all motors"
     export function stopAllMotor(): void {
         setMotorSpeed(MotorList.M1, 0)
         setMotorSpeed(MotorList.M2, 0)
@@ -133,14 +135,15 @@ namespace neZha {
         setMotorSpeed(MotorList.M4, 0)
     }
 
-	/*
-     * TODO: Setting the angle of a servo motor. 
+	/**
+     * Sets the angle of a servo motor.
+     * @param servoType A servo type in ServoTypeList
      * @param servo A servo in the ServoList 
      * @param angel Angle of servo motor
      */
     //% weight=84
-    //% blockId=setServoAngel block="Set %servoType servo %servo angel to %angle°"
-    export function setServoAngel(servoType:ServoTypeList,servo: ServoList, angel: number): void {
+    //% blockId=setServoAngel block="Set %servoType servo %servo angle to %angle°"
+    export function setServoAngel(servoType: ServoTypeList, servo: ServoList, angel: number): void {
         let iic_buffer = pins.createBuffer(4);
         switch (servo) {
             case ServoList.S1:
@@ -172,10 +175,10 @@ namespace neZha {
         iic_buffer[3] = 0;
         pins.i2cWriteBuffer(neZha_address, iic_buffer);
     }
-    /*
-     * TODO: Setting the speed of a servo motor. 
-     * @param servo A servo in the ServoList 
-     * @param angel Angle of servo motor 
+    /**
+     * Sets the speed of a servo motor. 
+     * @param servo A servo in the ServoList
+     * @param speed Speed of the servo motor
      */
     //% weight=83
     //% blockId=setServoSpeed block="Set continuous rotation servo %servo speed to %speed\\%"

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-nezha",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "description": "The micro:bit extension board Nezha(哪吒) with RJ11 connection port by ELECFREAKS Co.ltd",
     "dependencies": {
         "core": "*",
@@ -10,7 +10,9 @@
         "README.md",
         "main.ts",
         "_locales/zh/pxt-nezha-strings.json",
-        "_locales/el/pxt-nezha-strings.json"
+        "_locales/el/pxt-nezha-strings.json",
+        "_locales/cs/pxt-nezha-strings.json",
+        "_locales/cs/pxt-nezha-jsdoc-strings.json"
     ],
     "testFiles": [
         "test.ts"


### PR DESCRIPTION
- Fist commit adds Czech translation
- Second commit performs some minor fixes of typos in JS doc comments (e.g. angel -> angle)
- Function names / block IDs were left intact (even if there's a typo in them) in order to keep backward compatibility with old user code
- The `_locales/nezha-jsdoc-strings.json` now contains full set of ID:text pairs to aid translators to other languages